### PR TITLE
Client concern separation

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -216,13 +216,9 @@ func (t *Terminal) RunClient() error {
 				// Add a new item below current cursor position
 				var err error
 				if t.curY == 0 {
-					if len(matches) == 0 {
-						err = t.db.Add("", nil, true)
-					} else {
-						err = t.db.Add("", matches[0], true)
-					}
+					err = t.db.Add("", nil)
 				} else {
-					err = t.db.Add("", t.curItem, false)
+					err = t.db.Add("", t.curItem)
 				}
 				if err != nil {
 					log.Fatal(err)
@@ -329,8 +325,11 @@ func (t *Terminal) RunClient() error {
 		//    emitStr(t.s, 0, t.h-1, t.style, strID)
 		//}
 
-		// TODO visibility of curItem should be handled by the client side, the backend should't now
-		matches, err = t.db.Match(t.search, t.curItem)
+		var cur *service.ListItem
+		if t.curItem != nil {
+			cur = t.curItem
+		}
+		matches, err = t.db.Match(t.search, cur)
 		if err != nil {
 			log.Println("stdin:", err)
 			break

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -17,7 +17,7 @@ import (
 type ListRepo interface {
 	Load() error
 	Save() error
-	Add(line string, item *ListItem, addAsChild bool) (*ListItem, error)
+	Add(line string, item *ListItem, addAsChild bool) error
 	Update(line string, listItem *ListItem) error
 	Delete(listItem *ListItem) error
 	Match(keys [][]rune, active *ListItem) ([]*ListItem, error)
@@ -250,7 +250,7 @@ func (r *DBListRepo) Save() error {
 	return nil
 }
 
-func (r *DBListRepo) Add(line string, item *ListItem, addAsChild bool) (*ListItem, error) {
+func (r *DBListRepo) Add(line string, item *ListItem, addAsChild bool) error {
 	newItem := ListItem{
 		Line: line,
 		ID:   r.NextID,
@@ -260,7 +260,7 @@ func (r *DBListRepo) Add(line string, item *ListItem, addAsChild bool) (*ListIte
 	// If `item` is nil, it's the first item in the list so set as root and return
 	if item == nil {
 		r.Root = &newItem
-		return &newItem, nil
+		return nil
 	}
 
 	if !addAsChild {
@@ -288,7 +288,7 @@ func (r *DBListRepo) Add(line string, item *ListItem, addAsChild bool) (*ListIte
 		}
 	}
 
-	return &newItem, nil
+	return nil
 }
 
 func (r *DBListRepo) Update(line string, listItem *ListItem) error {


### PR DESCRIPTION
Separate the client logic to handle distinct parts on the loop of each input event, as follows:

1. Mutate the underlying full linked list data
2. Set the new vertical position
3. Refresh the current item
4. Set the new horizontal position

This allowed me to clean up a lot of the service logic, and decouple both services.